### PR TITLE
Update to support python3 > 3.12

### DIFF
--- a/bootstrap4form/meta.py
+++ b/bootstrap4form/meta.py
@@ -1,5 +1,7 @@
-from distutils.version import StrictVersion
-
-
-VERSION = StrictVersion('4.0.2')
-
+from packaging.version import Version, parse
+from platform import python_version
+if Version(python_version()) >= Version('3.10'):
+    VERSION = Version('4.0.2')
+else:
+    from distutils.version import StrictVersion
+    VERSION = StrictVersion('4.0.2')

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license='MIT',
     test_suite='runtests.runtests',
     install_requires = [
-        "django>=2.2,<3",
+        "django>=2.2",
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Since python3.10 distutils is deprecated, since python3.12 it is not available anymore.

This PR uses packaging.version.Version() instead of distutils StrictVersion() for python version > 3.10
